### PR TITLE
Inclusão link para contato via WhatsApp

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
              <div>
                  <h2>CONTATO</h2>
                  <p>Você pode entrar em contato conosco através do email contato@barbeariastylus.com.br ou através do telefone (31) 99606-8639 (WhatsApp)</p>
-                 <a href="https://w.app/FTsogC" target="_blank">Fale conosco no WhatsApp</a>
+                 <!-- <a href="https://w.app/FTsogC" target="_blank">Fale conosco no WhatsApp</a> -->
+                 <a href=" https://wa.me/+5531996068639" target="_blank">Fale conosco no WhatsApp</a>
             </div>
 
 </body>


### PR DESCRIPTION
Olá, O link para contato via Whatsapp era direcionado para um serviço pago. Sugestão:
Usar a própria API do WhatsApp, segura e grátis!